### PR TITLE
Añado cuentas contables para ajustes positivos en IGIC, raiz de códigos para modelo 420 y posición fiscal para Canarias

### DIFF
--- a/l10n_es_igic/__openerp__.py
+++ b/l10n_es_igic/__openerp__.py
@@ -23,9 +23,10 @@
     "name": "IGIC (Impuesto General Indirecto Canario)",
     "version": "8.0.0.1",
     "author": "David Diz Martínez <daviddiz@gmail.com>,"
+              "Atlantux Consultores - Enrique Zanardi,",
               "Odoo Community Association (OCA)",
     "website": "https://github.com/daviddiz/igic",
-    "category": "Localisation/Europe",
+    "category": "Localization/Europe",
     "depends": [
         "l10n_es",
     ],
@@ -36,6 +37,7 @@
         "data/tax_codes_igic.xml",
         "data/taxes_igic.xml",
         "data/account_chart_template_igic_post.xml",
+        "data/fiscal_positions_igic.xml",
     ],
     'images': [],
     "demo": [],

--- a/l10n_es_igic/data/account_account_igic.xml
+++ b/l10n_es_igic/data/account_account_igic.xml
@@ -122,5 +122,45 @@
             <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
         </record>
 
+        <record id="pgc_6393" model="account.account.template">
+            <field name="code">6393</field>
+            <field name="reconcile" eval="False"/>
+            <field name="parent_id" ref="l10n_es.pgc_639"/>
+            <field name="type">view</field>
+            <field name="name">Ajustes positivos en IGIC de circulante</field>
+            <field name="user_type" ref="account.data_account_type_expense"/>
+            <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        </record>
+        
+        <record id="pgc_6393_child" model="account.account.template">
+            <field name="code">6393</field>
+            <field name="reconcile" eval="False"/>
+            <field name="parent_id" ref="pgc_6393"/>
+            <field name="type">other</field>
+            <field name="name">Ajustes positivos en IGIC de circulante</field>
+            <field name="user_type" ref="account.data_account_type_expense"/>
+            <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        </record>
+        
+        <record id="pgc_6394" model="account.account.template">
+            <field name="code">6394</field>
+            <field name="reconcile" eval="False"/>
+            <field name="parent_id" ref="l10n_es.pgc_639"/>
+            <field name="type">view</field>
+            <field name="name">Ajustes positivos en IGIC de inversión</field>
+            <field name="user_type" ref="account.data_account_type_expense"/>
+            <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        </record>
+        
+        <record id="pgc_6394_child" model="account.account.template">
+            <field name="code">6394</field>
+            <field name="reconcile" eval="False"/>
+            <field name="parent_id" ref="pgc_6394"/>
+            <field name="type">other</field>
+            <field name="name">Ajustes positivos en IGIC de inversión</field>
+            <field name="user_type" ref="account.data_account_type_expense"/>
+            <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        </record>
+
     </data>
 </openerp>

--- a/l10n_es_igic/data/fiscal_positions_igic.xml
+++ b/l10n_es_igic/data/fiscal_positions_igic.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <!-- Definición de posición fiscal para Importaciones a Canarias y Exportaciones desde Canarias
+
+        Enrique Zanardi (Atlantux Consultores) - consultores@atlantux.com (2016-11-08)
+        -->
+
+        <!-- ************************************************************* -->
+        <!-- Fiscal Position Templates -->
+        <!-- ************************************************************* -->
+
+        <record id="fp_extra_canarias" model="account.fiscal.position.template">
+            <field name="name">
+                Régimen de Importaciones/Exportaciones a/desde Canarias
+            </field>
+            <field name="chart_template_id" ref="account_chart_template_pymes_canarias"/>
+        </record>
+
+        <!-- ************************************************************* -->
+        <!-- Fiscal Position Tax Templates -->
+        <!-- ************************************************************* -->
+
+        <!-- Importaciones/Exportaciones a/desde Canarias -->
+
+        <record id="fptt_extra_canarias_s_igic0" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_s_igic0"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_igic0_exp"/>
+        </record>
+        <record id="fptt_extra_canarias_s_igic3" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_s_igic3"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_igic0_exp"/>
+        </record>
+        <record id="fptt_extra_canarias_s_igic7" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_s_igic7"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_igic0_exp"/>
+        </record>
+        <record id="fptt_extra_canarias_s_igic95" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_s_igic95"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_igic0_exp"/>
+        </record>
+        <record id="fptt_extra_canarias_s_igic135" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_s_igic135"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_igic0_exp"/>
+        </record>
+        <record id="fptt_extra_canarias_s_igic20" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_s_igic20"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_igic0_exp"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic0_oc" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic0_oc"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic0_ibc"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic3_oc" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic3_oc"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic3_ibc"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic7_oc" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic7_oc"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic7_ibc"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic95_oc" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic95_oc"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic95_ibc"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic135_oc" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic135_oc"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic135_ibc"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic20_oc" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic20_oc"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic20_ibc"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic0_bi" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic0_bi"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic0_ibi"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic3_bi" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic3_bi"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic3_ibi"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic7_bi" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic7_bi"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic7_ibi"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic95_bi" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic95_bi"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic95_ibi"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic135_bi" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic135_bi"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic135_ibi"/>
+        </record>
+        <record id="fptt_extra_canarias_c_igic20_bi" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_extra_canarias"/>
+            <field name="tax_src_id" ref="account_tax_template_c_igic20_bi"/>
+            <field name="tax_dest_id" ref="account_tax_template_c_igic20_ibi"/>
+        </record>
+
+    </data>
+</openerp>

--- a/l10n_es_igic/data/tax_codes_igic.xml
+++ b/l10n_es_igic/data/tax_codes_igic.xml
@@ -6,7 +6,16 @@
 
         David Diz Martínez - daviddiz@gmail.com (2015-10-29)
           Refactorización general
+        Enrique Zanardi (Atlantux Consultores) - consultores@atlantux.com (2016-11-02)
+          Añadido raiz de códigos para modelo 420
         -->
+
+        <record id="account_tax_code_template_420" model="account.tax.code.template">
+            <field name="code">420</field>
+            <field name="name">&lt;Mod. 420&gt; Impuesto General Indirecto Canario. Régimen general. Autoliquidación trimestral</field>
+            <field name="sign">1.0</field>
+            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+        </record>
         
         <!-- IGIC Devengado Bases -->
 	
@@ -14,7 +23,7 @@
             <field name="name">Régimen general IGIC devengado. Base Imponible</field>
             <field name="code">IGICDBI</field>
             <field name="sign">1.0</field>
-            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+            <field name="parent_id" ref="account_tax_code_template_420"/>
         </record>
 
         <record id="account_tax_code_template_IGICDBI0" model="account.tax.code.template">
@@ -65,7 +74,7 @@
             <field name="name">[15] Régimen general IGIC devengado. Cuota</field>
             <field name="code">IGICDC</field>
             <field name="sign">1.0</field>
-            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+            <field name="parent_id" ref="account_tax_code_template_420"/>
         </record>
 
         <record id="account_tax_code_template_IGICDC0" model="account.tax.code.template">
@@ -116,7 +125,7 @@
             <field name="name">IGIC soportado. Base Imponible</field>
             <field name="code">IGICSBI</field>
             <field name="sign">1.0</field>
-            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+            <field name="parent_id" ref="account_tax_code_template_420"/>
         </record>
 
         <record id="account_tax_code_template_IGICOICBI" model="account.tax.code.template">
@@ -432,21 +441,21 @@
         <record id="account_tax_code_template_IGICEI" model="account.tax.code.template">
             <field name="name">IGIC Entregas Intracomunitarias</field>
             <field name="code">IGICEI</field>
-            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+            <field name="parent_id" ref="account_tax_code_template_420"/>
             <field name="sign">1.0</field>
         </record>
 
         <record id="account_tax_code_template_IGICEYOA" model="account.tax.code.template">
             <field name="name">IGIC Exportaciones y operaciones asimiladas</field>
             <field name="code">IGICEYOA</field>
-            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+            <field name="parent_id" ref="account_tax_code_template_420"/>
             <field name="sign">1.0</field>
         </record>
 
         <record id="account_tax_code_template_IGICISP" model="account.tax.code.template">
             <field name="name">[13] IGIC Inversión del sujeto pasivo</field>
             <field name="code">IGICISP</field>
-            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+            <field name="parent_id" ref="account_tax_code_template_420"/>
             <field name="sign">1.0</field>
         </record>
         
@@ -455,7 +464,7 @@
         <record id="account_tax_code_template_IGICTADC" model="account.tax.code.template">
             <field name="name">[22] IGIC total a deducir. Cuota</field>
             <field name="code">IGICTADC</field>
-            <field name="parent_id" ref="l10n_es.account_tax_code_template_root"/>
+            <field name="parent_id" ref="account_tax_code_template_420"/>
             <field name="sign">1.0</field>
         </record>
         


### PR DESCRIPTION
Revisando el Pull Request [235](https://github.com/OCA/l10n-spain/pull/235) que enviaste hace un año para añadir el IGIC al Odoo, me he dado cuenta de que faltan las cuentas contables para ajustes positivos del IGIC (6393 y 6394). Te mando un PR con esas cuentas.
Si te parece bien, puedo dedicarle un tiempo a preparar las posiciones fiscales que quería Pedro Baeza para considerar el módulo como completo y que le dé el visto bueno...